### PR TITLE
Remove supernumerary latest-[random string] tags

### DIFF
--- a/builds/acr-cleanup/template.yaml
+++ b/builds/acr-cleanup/template.yaml
@@ -10,6 +10,27 @@ jobs:
   timeoutInMinutes: 600
   steps:
   - task: AzureCLI@1
+    displayName: 'Delete latest-[random string] supernumerary tags'
+    inputs:
+      azureSubscription: ${{ parameters.serviceConnection }}
+      scriptLocation: inlineScript
+      inlineScript: |
+        REPOSITORIES=$(az acr repository list --name ${{ parameters.acrName }} --resource-group ${{ parameters.acrResourceGroup }} -o tsv)
+        for repo in $REPOSITORIES
+        do
+          printf "Deleting supernumerary latest-[random string] tags for $repo\n"
+          az acr repository show-manifests \
+            --name ${{ parameters.acrName }} \
+            --repository $repo \
+            --query "[?tags[?contains(@, 'latest-')] && tags[0] != 'latest'].digest" \
+            -o tsv \
+              | xargs -I% az acr repository delete \
+                --name ${{ parameters.acrName }} \
+                --image $repo@% \
+                --yes
+        done
+
+  - task: AzureCLI@1
     displayName: 'Delete dangling image layers'
     inputs:
       azureSubscription:  ${{ parameters.serviceConnection }}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-1016

### Change description ###

This PR extends the daily dangling images cleanup with the deletion of images with tags matching the following pattern: `latest-5om3str1ng` _except_ those tagged with `latest` as well.

It should let any other kind of tag intact.

Tested on the `hmctssandbox` registry: https://dev.azure.com/hmcts/CNP/_build/results?buildId=7230

![Group](https://user-images.githubusercontent.com/602143/54197541-1e09a600-44bc-11e9-8d0a-a80fa4670d14.png)

---

Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
