### PR TITLE
Adding consul dns registration build for preview

### DIFF
--- a/builds/consul/register-dcd-cnp-dev-preview.yaml
+++ b/builds/consul/register-dcd-cnp-dev-preview.yaml
@@ -1,0 +1,11 @@
+name: Register Consul (DCD-CNP-DEV-PREVIEW)
+trigger: none
+pr: none
+
+jobs:
+  - template: template.yaml
+    parameters:
+      serviceName: $(serviceName)
+      serviceAddress: 10.97.17.51
+      consulAddress: 10.97.8.4
+      agentPool: hmcts-agent-pool


### PR DESCRIPTION
This is for IDAM to be able to register one-off DNS for preview testing.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
