### PR TITLE
Fixing failed release alerts

### DIFF
--- a/scripts/helm-release-status.sh
+++ b/scripts/helm-release-status.sh
@@ -29,7 +29,7 @@ for ns in $(echo ${!namespaceMapping[*]}); do
   echo "Processing failed releases for namespace ${ns}"
   failedReleaseNames=""
 
-  for release in $( helm ls --namespace=${ns} --failed --short); do
+  for release in $( helm ls --namespace=${ns} -o json | jq -r '.[] | select( .status | contains("failed")) | .name'); do
       echo "Found a failed release $release"
       failedReleaseNames+=$release" "
   done


### PR DESCRIPTION
helm ls --failed seems to have changed the behaviour and shows up when there is a failure in the history and not latest .

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
