### PR TITLE
Fix overriding cutOffDays

### DIFF
--- a/builds/aks-cleanup/preview-scheduled-cleanup.yml
+++ b/builds/aks-cleanup/preview-scheduled-cleanup.yml
@@ -13,7 +13,6 @@ schedules:
 variables:
   helmVersion: '3.2.4'
   azureSubscription: DCD-CFTAPPS-DEV
-  cutoffDays: 4
 
 jobs:
   - job: delete_helm_release


### PR DESCRIPTION
> To allow a variable to be set at queue time, make sure it doesn't appear in the variables block of a pipeline or job.

https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch