### PR TITLE
Dtspo-18162 clean up more of our ACR repositories

### DIFF
--- a/builds/acr-cleanup/README.md
+++ b/builds/acr-cleanup/README.md
@@ -1,0 +1,6 @@
+## ACR Cleanup
+This pipeline is responsible for cleaning up the ACR repository by deleting images that are older than a certain number 
+of days and that they match defined patterns in RegEx <repo-regEx:image-regEx> e.g. `"^labs/.*:.*", "^toffee.*:.*", "^plum.*:.*"`. 
+The number of days is configurable in the pipeline.
+
+The pipeline is scheduled to run every workday at 5:12 AM UTC.

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -28,26 +28,18 @@ parameters:
   - name: cleanup_patterns
     type: object
     default:
-      - repoRegex: ".*"
-        olderThan: "5d"
-        tagFilter: "^prod.*"
+      - olderThan: "5d"
         keep: 5
         repoTagFilters: [".*:^prod.*"]
-      - repoRegex: ".*"
-        olderThan: "2d"
-        tagFilter: "^staging-.*"
+      - olderThan: "2d"
         keep: 2
         repoTagFilters: [".*:^staging-.*"]
-      - repoRegex: ".*"
-        olderThan: "14d"
-        tagFilter: "^pr-.*"
+      - olderThan: "14d"
         keep: 1
         repoTagFilters: [".*:^pr-.*"]
-      - repoRegex: "^labs/.*"
-        olderThan: "14d"
-        tagFilter: ".*"
+      - olderThan: "14d"
         keep: 1
-        repoTagFilters: ["^labs/ieuanb74:.*", "^labs/jordankainos:.*"]
+        repoTagFilters: ["^labs/.*:.*", "^toffee.*:.*", "^plum.*:.*"]
 
 jobs:
   - ${{ each cleanup_registry in parameters.cleanup_registries }}:
@@ -67,4 +59,4 @@ jobs:
                   azureSubscription: ${{ cleanup_registry.serviceConnection }}
                   scriptLocation: scriptPath
                   scriptPath: scripts/cleanup-acr-old-images.sh
-                  arguments: ${{cleanup_registry.acrName}} ${{cleanup_pattern.repoRegex}} ${{cleanup_pattern.tagFilter}} ${{cleanup_pattern.olderThan}} ${{cleanup_pattern.keep}} ${{variables.repoTagFiltersString}}
+                  arguments: ${{cleanup_registry.acrName}} ${{cleanup_pattern.olderThan}} ${{cleanup_pattern.keep}} ${{variables.repoTagFiltersString}}

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -45,7 +45,7 @@ jobs:
   - ${{ each cleanup_registry in parameters.cleanup_registries }}:
       - ${{ each cleanup_pattern in parameters.cleanup_patterns }}:
           - job:
-            displayName: "${{cleanup_registry.acrName}} - ${{cleanup_pattern.tagFilter}} " # Human-readable name for the job.
+            displayName: "${{cleanup_registry.acrName}} - OlderThan ${{cleanup_patterns.olderThan}} keep ${{cleanup_patterns.keep}}" # Human-readable name for the job.
             pool:
               vmImage: "ubuntu-latest"
             timeoutInMinutes: 600

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -1,7 +1,6 @@
 ---
 name: Clean up old tags from ACR
-trigger:
-  - DTSPO-18162_cleanUpMoreACRRepos
+trigger: none
 pr: none
 schedules:
   - cron: "12 5 * * Mon-Fri"
@@ -21,8 +20,8 @@ parameters:
         acrName: 'hmctsprivate'
       - serviceConnection: DTS-SHAREDSERVICES-PROD
         acrName: 'sdshmctspublic'
-#      - serviceConnection: azurerm-sandbox
-#        acrName: "hmctssandbox"
+      - serviceConnection: azurerm-sandbox
+        acrName: "hmctssandbox"
 
   - name: cleanup_patterns
     type: object

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -40,7 +40,7 @@ parameters:
         olderThan: "14d"
         tagFilter: "^pr-.*"
         keep: 1
-      - repoRegex: '^labs/endakelly-test'
+      - repoRegex: '^labs/.*'
         olderThan: "14d"
         tagFilter: ".*"
         keep: 1

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -40,8 +40,8 @@ parameters:
         olderThan: "14d"
         tagFilter: "^pr-.*"
         keep: 1
-      - repoRegex: '^labs/endakelly-spring.*'
-        olderThan: "30d"
+      - repoRegex: '^labs/endakelly-test'
+        olderThan: "14d"
         tagFilter: ".*"
         keep: 1
 

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -1,6 +1,7 @@
 ---
 name: Clean up old tags from ACR
-trigger: DTSPO-18162_cleanUpMoreACRRepos
+trigger:
+  - DTSPO-18162_cleanUpMoreACRRepos
 pr: none
 schedules:
   - cron: '12 5 * * Mon-Fri'

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -4,65 +4,65 @@ trigger:
   - DTSPO-18162_cleanUpMoreACRRepos
 pr: none
 schedules:
-  - cron: '12 5 * * Mon-Fri'
+  - cron: "12 5 * * Mon-Fri"
     displayName: At 05:12 on every day-of-week from Monday through Friday
     branches:
       include:
         - master
-    always: 'true'
+    always: "true"
 
 parameters:
   - name: cleanup_registries
     type: object
     default:
       #hmctspublic
-#      - serviceConnection: azurerm-prod
-#        acrName: 'hmctspublic'
-#      - serviceConnection: azurerm-prod
-#        acrName: 'hmctsprivate'
-#      - serviceConnection: DTS-SHAREDSERVICES-PROD
-#        acrName: 'sdshmctspublic'
+      #      - serviceConnection: azurerm-prod
+      #        acrName: 'hmctspublic'
+      #      - serviceConnection: azurerm-prod
+      #        acrName: 'hmctsprivate'
+      #      - serviceConnection: DTS-SHAREDSERVICES-PROD
+      #        acrName: 'sdshmctspublic'
       - serviceConnection: azurerm-sandbox
-        acrName: 'hmctssandbox'
+        acrName: "hmctssandbox"
 
   - name: cleanup_patterns
     type: object
     default:
-      - repoRegex: '.*'
+      - repoRegex: ".*"
         olderThan: "5d"
         tagFilter: "^prod.*"
         keep: 5
-        repoTagFilters: ['.*:^prod.*']
-      - repoRegex: '.*'
+        repoTagFilters: [".*:^prod.*"]
+      - repoRegex: ".*"
         olderThan: "2d"
         tagFilter: "^staging-.*"
         keep: 2
-        repoTagFilters: ['.*:^staging-.*']
-      - repoRegex: '.*'
+        repoTagFilters: [".*:^staging-.*"]
+      - repoRegex: ".*"
         olderThan: "14d"
         tagFilter: "^pr-.*"
         keep: 1
-        repoTagFilters: ['.*:^pr-.*']
-      - repoRegex: '^labs/.*'
+        repoTagFilters: [".*:^pr-.*"]
+      - repoRegex: "^labs/.*"
         olderThan: "14d"
         tagFilter: ".*"
         keep: 1
-        repoTagFilters: ['^labs/ieuanb74:.*', '^labs/jordankainos:.*']
+        repoTagFilters: ["^labs/ieuanb74:.*", "^labs/jordankainos:.*"]
 
 jobs:
   - ${{ each cleanup_registry in parameters.cleanup_registries }}:
-    - ${{ each cleanup_pattern in parameters.cleanup_patterns }}:
-      - job:
-        displayName: "${{cleanup_registry.acrName}} - ${{cleanup_pattern.tagFilter}} " # Human-readable name for the job.
-        pool:
-          vmImage: 'ubuntu-latest'
-        timeoutInMinutes: 600
-        steps:
-          - task: AzureCLI@1
-            displayName: 'Deleting ${{cleanup_pattern.tagFilter}} images from ${{cleanup_registry.acrName}} '
-            inputs:
-              scriptType: bash
-              azureSubscription: ${{ cleanup_registry.serviceConnection }}
-              scriptLocation: scriptPath
-              scriptPath: scripts/cleanup-acr-old-images.sh
-              arguments: ${{cleanup_registry.acrName}} ${{cleanup_pattern.repoRegex}} ${{cleanup_pattern.tagFilter}} ${{cleanup_pattern.olderThan}} ${{cleanup_pattern.keep}} ${{cleanup_pattern.repoTagFilters}}
+      - ${{ each cleanup_pattern in parameters.cleanup_patterns }}:
+          - job:
+            displayName: "${{cleanup_registry.acrName}} - ${{cleanup_pattern.tagFilter}} " # Human-readable name for the job.
+            pool:
+              vmImage: "ubuntu-latest"
+            timeoutInMinutes: 600
+            steps:
+              - task: AzureCLI@1
+                displayName: "Deleting ${{cleanup_pattern.tagFilter}} images from ${{cleanup_registry.acrName}} "
+                inputs:
+                  scriptType: bash
+                  azureSubscription: ${{ cleanup_registry.serviceConnection }}
+                  scriptLocation: scriptPath
+                  scriptPath: scripts/cleanup-acr-old-images.sh
+                  arguments: ${{cleanup_registry.acrName}} ${{cleanup_pattern.repoRegex}} ${{cleanup_pattern.tagFilter}} ${{cleanup_pattern.olderThan}} ${{cleanup_pattern.keep}} ${{ join(',' cleanup_pattern.repoTagFilters) }}

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -57,6 +57,8 @@ jobs:
             pool:
               vmImage: "ubuntu-latest"
             timeoutInMinutes: 600
+            variables:
+              repoTagFiltersString: ${{ join(',', cleanup_pattern.repoTagFilters) }}
             steps:
               - task: AzureCLI@1
                 displayName: "Deleting ${{cleanup_pattern.tagFilter}} images from ${{cleanup_registry.acrName}} "
@@ -65,4 +67,4 @@ jobs:
                   azureSubscription: ${{ cleanup_registry.serviceConnection }}
                   scriptLocation: scriptPath
                   scriptPath: scripts/cleanup-acr-old-images.sh
-                  arguments: ${{cleanup_registry.acrName}} ${{cleanup_pattern.repoRegex}} ${{cleanup_pattern.tagFilter}} ${{cleanup_pattern.olderThan}} ${{cleanup_pattern.keep}} ${{ join(',' cleanup_pattern.repoTagFilters) }}
+                  arguments: ${{cleanup_registry.acrName}} ${{cleanup_pattern.repoRegex}} ${{cleanup_pattern.tagFilter}} ${{cleanup_pattern.olderThan}} ${{cleanup_pattern.keep}} ${{variables.repoTagFiltersString}}

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -45,7 +45,7 @@ jobs:
   - ${{ each cleanup_registry in parameters.cleanup_registries }}:
       - ${{ each cleanup_pattern in parameters.cleanup_patterns }}:
           - job:
-            displayName: "${{cleanup_registry.acrName}} - OlderThan ${{cleanup_patterns.olderThan}} keep ${{cleanup_patterns.keep}}" # Human-readable name for the job.
+            displayName: "${{cleanup_registry.acrName}} - OlderThan ${{cleanup_pattern.olderThan}} keep ${{cleanup_pattern.keep}}" # Human-readable name for the job.
             pool:
               vmImage: "ubuntu-latest"
             timeoutInMinutes: 600

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -16,8 +16,8 @@ parameters:
     type: object
     default:
       #hmctspublic
-      #      - serviceConnection: azurerm-prod
-      #        acrName: 'hmctspublic'
+#      - serviceConnection: azurerm-prod
+#        acrName: 'hmctspublic'
       #      - serviceConnection: azurerm-prod
       #        acrName: 'hmctsprivate'
       #      - serviceConnection: DTS-SHAREDSERVICES-PROD

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -15,15 +15,14 @@ parameters:
   - name: cleanup_registries
     type: object
     default:
-      #hmctspublic
-#      - serviceConnection: azurerm-prod
-#        acrName: 'hmctspublic'
-      #      - serviceConnection: azurerm-prod
-      #        acrName: 'hmctsprivate'
-      #      - serviceConnection: DTS-SHAREDSERVICES-PROD
-      #        acrName: 'sdshmctspublic'
-      - serviceConnection: azurerm-sandbox
-        acrName: "hmctssandbox"
+      - serviceConnection: azurerm-prod
+        acrName: 'hmctspublic'
+      - serviceConnection: azurerm-prod
+        acrName: 'hmctsprivate'
+      - serviceConnection: DTS-SHAREDSERVICES-PROD
+        acrName: 'sdshmctspublic'
+#      - serviceConnection: azurerm-sandbox
+#        acrName: "hmctssandbox"
 
   - name: cleanup_patterns
     type: object

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -1,6 +1,6 @@
 ---
 name: Clean up old tags from ACR
-trigger: none
+trigger: DTSPO-18162_cleanUpMoreACRRepos
 pr: none
 schedules:
   - cron: '12 5 * * Mon-Fri'
@@ -15,12 +15,12 @@ parameters:
     type: object
     default:
       #hmctspublic
-      - serviceConnection: azurerm-prod
-        acrName: 'hmctspublic'
-      - serviceConnection: azurerm-prod
-        acrName: 'hmctsprivate'
-      - serviceConnection: DTS-SHAREDSERVICES-PROD
-        acrName: 'sdshmctspublic'
+#      - serviceConnection: azurerm-prod
+#        acrName: 'hmctspublic'
+#      - serviceConnection: azurerm-prod
+#        acrName: 'hmctsprivate'
+#      - serviceConnection: DTS-SHAREDSERVICES-PROD
+#        acrName: 'sdshmctspublic'
       - serviceConnection: azurerm-sandbox
         acrName: 'hmctssandbox'
 
@@ -38,6 +38,10 @@ parameters:
       - repoRegex: '.*'
         olderThan: "14d"
         tagFilter: "^pr-.*"
+        keep: 1
+      - repoRegex: '^labs/endakelly-spring.*'
+        olderThan: "30d"
+        tagFilter: ".*"
         keep: 1
 
 jobs:

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -32,18 +32,22 @@ parameters:
         olderThan: "5d"
         tagFilter: "^prod.*"
         keep: 5
+        repoTagFilters: ['.*:^prod.*']
       - repoRegex: '.*'
         olderThan: "2d"
         tagFilter: "^staging-.*"
         keep: 2
+        repoTagFilters: ['.*:^staging-.*']
       - repoRegex: '.*'
         olderThan: "14d"
         tagFilter: "^pr-.*"
         keep: 1
+        repoTagFilters: ['.*:^pr-.*']
       - repoRegex: '^labs/.*'
         olderThan: "14d"
         tagFilter: ".*"
         keep: 1
+        repoTagFilters: ['^labs/ieuanb74:.*', '^labs/jordankainos:.*']
 
 jobs:
   - ${{ each cleanup_registry in parameters.cleanup_registries }}:
@@ -61,4 +65,4 @@ jobs:
               azureSubscription: ${{ cleanup_registry.serviceConnection }}
               scriptLocation: scriptPath
               scriptPath: scripts/cleanup-acr-old-images.sh
-              arguments: ${{cleanup_registry.acrName}} ${{cleanup_pattern.repoRegex}} ${{cleanup_pattern.tagFilter}} ${{cleanup_pattern.olderThan}} ${{cleanup_pattern.keep}}
+              arguments: ${{cleanup_registry.acrName}} ${{cleanup_pattern.repoRegex}} ${{cleanup_pattern.tagFilter}} ${{cleanup_pattern.olderThan}} ${{cleanup_pattern.keep}} ${{cleanup_pattern.repoTagFilters}}

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -36,10 +36,7 @@ parameters:
         repoTagFilters: [".*:^staging-.*"]
       - olderThan: "14d"
         keep: 1
-        repoTagFilters: [".*:^pr-.*"]
-      - olderThan: "14d"
-        keep: 1
-        repoTagFilters: ["^labs/.*:.*", "^toffee.*:.*", "^plum.*:.*"]
+        repoTagFilters: [".*:^pr-.*", "^labs/.*:.*", "^toffee.*:.*", "^plum.*:.*"]
 
 jobs:
   - ${{ each cleanup_registry in parameters.cleanup_registries }}:

--- a/scripts/cleanup-acr-old-images.sh
+++ b/scripts/cleanup-acr-old-images.sh
@@ -18,5 +18,5 @@ done
 echo "$(TERM=xterm tput setaf 2)Cleaning up $registry, deleting [${filter_args}] images older than $older_than and keeping at least $keep_min_latest_num"
 
 az acr run --registry "$registry" \
- --cmd "acr purge --registry \$RegistryName ${filter_args} --ago ${older_than} --keep ${keep_min_latest_num} --dry-run --untagged --concurrency 5" \
+ --cmd "acr purge --registry \$RegistryName ${filter_args} --ago ${older_than} --keep ${keep_min_latest_num} --untagged --concurrency 5" \
  --timeout 10800  /dev/null

--- a/scripts/cleanup-acr-old-images.sh
+++ b/scripts/cleanup-acr-old-images.sh
@@ -18,5 +18,5 @@ done
 echo "$(TERM=xterm tput setaf 2)Cleaning up $registry, deleting [${filter_args}] images older than $older_than and keeping at least $keep_min_latest_num"
 
 az acr run --registry "$registry" \
- --cmd "acr purge --registry \$RegistryName ${filter_args} --ago ${older_than} --keep ${keep_min_latest_num}  --untagged --concurrency 5" \
+ --cmd "acr purge --registry \$RegistryName ${filter_args} --ago ${older_than} --keep ${keep_min_latest_num} --dry-run --untagged --concurrency 5" \
  --timeout 10800  /dev/null

--- a/scripts/cleanup-acr-old-images.sh
+++ b/scripts/cleanup-acr-old-images.sh
@@ -9,8 +9,20 @@ repo_regex="${2:-.*}"
 tag_filter="${3:-^ignore-.*}"
 older_than="${4:-30d}"
 keep_min_latest_num="${5:-5}"
+repo_tag_filters="${6:['-.*:-^ignore-.*']}"
 
 
 echo "$(TERM=xterm tput setaf 2)Cleaning up $registry, deleting ${tag_filter} images older than $older_than and keeping at least $keep_min_latest_num"
 
-az acr run --registry $registry --cmd "acr purge --registry \$RegistryName --filter ${repo_regex}:${tag_filter} --ago ${older_than} --keep ${keep_min_latest_num}  --untagged --concurrency 5" --timeout 10800  /dev/null
+# iterate repo_tag_filters and build "--filter" arguments
+filter_args=""
+for repo_tag_filter in "${repo_tag_filters[@]}"
+do
+  filter_args="$filter_args --filter $repo_tag_filter"
+done
+
+echo "filter_args: $filter_args"
+
+az acr run --registry $registry \
+ --cmd "acr purge --registry \$RegistryName ${filter_args} --ago ${older_than} --keep ${keep_min_latest_num}  --untagged --concurrency 5" \
+ --timeout 10800  /dev/null

--- a/scripts/cleanup-acr-old-images.sh
+++ b/scripts/cleanup-acr-old-images.sh
@@ -11,11 +11,10 @@ older_than="${4:-30d}"
 keep_min_latest_num="${5:-5}"
 repo_tag_filters="${6:-.*:-^ignore-.*}"
 
-
+echo "repo_tag_filters: $repo_tag_filters"
 echo "$(TERM=xterm tput setaf 2)Cleaning up $registry, deleting ${tag_filter} images older than $older_than and keeping at least $keep_min_latest_num"
 
-repo_tag_filters="^labs/ieuanb74:.*,^labs/jordankainos:.*"
-
+#repo_tag_filters="^labs/ieuanb74:.*,^labs/jordankainos:.*"
 IFS=',' read -r -a repo_tag_array <<< "$repo_tag_filters"
 
 filter_args=""
@@ -25,6 +24,6 @@ done
 
 echo "filter_args: $filter_args"
 
-az acr run --registry $registry \
+az acr run --registry "$registry" \
  --cmd "acr purge --registry \$RegistryName ${filter_args} --ago ${older_than} --keep ${keep_min_latest_num}  --untagged --concurrency 5" \
  --timeout 10800  /dev/null

--- a/scripts/cleanup-acr-old-images.sh
+++ b/scripts/cleanup-acr-old-images.sh
@@ -5,24 +5,17 @@
 set -e
 
 registry=${1:-hmctspublic}
-repo_regex="${2:-.*}"
-tag_filter="${3:-^ignore-.*}"
-older_than="${4:-30d}"
-keep_min_latest_num="${5:-5}"
-repo_tag_filters="${6:-.*:-^ignore-.*}"
+older_than="${2:-30d}"
+keep_min_latest_num="${3:-5}"
+repo_tag_filters="${4:-.*:-^ignore-.*}"
 
-echo "repo_tag_filters: $repo_tag_filters"
-echo "$(TERM=xterm tput setaf 2)Cleaning up $registry, deleting ${tag_filter} images older than $older_than and keeping at least $keep_min_latest_num"
-
-#repo_tag_filters="^labs/ieuanb74:.*,^labs/jordankainos:.*"
 IFS=',' read -r -a repo_tag_array <<< "$repo_tag_filters"
 
 filter_args=""
 for repo_tag_filter in "${repo_tag_array[@]}"; do
     filter_args="$filter_args --filter $repo_tag_filter"
 done
-
-echo "filter_args: $filter_args"
+echo "$(TERM=xterm tput setaf 2)Cleaning up $registry, deleting [${filter_args}] images older than $older_than and keeping at least $keep_min_latest_num"
 
 az acr run --registry "$registry" \
  --cmd "acr purge --registry \$RegistryName ${filter_args} --ago ${older_than} --keep ${keep_min_latest_num}  --untagged --concurrency 5" \

--- a/scripts/cleanup-acr-old-images.sh
+++ b/scripts/cleanup-acr-old-images.sh
@@ -9,16 +9,18 @@ repo_regex="${2:-.*}"
 tag_filter="${3:-^ignore-.*}"
 older_than="${4:-30d}"
 keep_min_latest_num="${5:-5}"
-repo_tag_filters="${6:['-.*:-^ignore-.*']}"
+repo_tag_filters="${6:-.*:-^ignore-.*}"
 
 
 echo "$(TERM=xterm tput setaf 2)Cleaning up $registry, deleting ${tag_filter} images older than $older_than and keeping at least $keep_min_latest_num"
 
-# iterate repo_tag_filters and build "--filter" arguments
+repo_tag_filters="^labs/ieuanb74:.*,^labs/jordankainos:.*"
+
+IFS=',' read -r -a repo_tag_array <<< "$repo_tag_filters"
+
 filter_args=""
-for repo_tag_filter in "${repo_tag_filters[@]}"
-do
-  filter_args="$filter_args --filter $repo_tag_filter"
+for repo_tag_filter in "${repo_tag_array[@]}"; do
+    filter_args="$filter_args --filter $repo_tag_filter"
 done
 
 echo "filter_args: $filter_args"


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-18162

### Change description ###

We are maintaining a few AC registries e.g. hmctsprivate, hmctspublic, etc, each registry contains many of container repos. The majority of ACR are under premium service tier. Azure Container Registry (ACR) charges for data storage based on the amount of storage used beyond the included allocation in each service tier. 500G of storage allocated for the premium service tier. 

the scheduler only picks up image tags match patterns : "^prod.”, "^staging-.”, and "^pr-.”
There are many repos that do not have image tags matching any of the patterns "^prod.”, "^staging-.”, or "^pr-.” ** e.g. docmosis, docmosis-base, base/node, base/java, labs/* etc
there are also so many untagged images : e.g.
Repo: base/node in registry hmctspublic Untagged images size: 1270 MBs 
Repo: base/java in registry hmctspublic Untagged images size: 2027 MBs

AS of now we decided to start by cleaning the repositories we are familiar with, rather than targeting those we don't know well. We start with these repos match the pattern `^labs/.*`

As part of solution I have also improved the way to define image filters to be cleaned up. 
Old: 
```
        repoRegex: '.*'
        olderThan: "14d"
        tagFilter: "^pr-.*"
        keep: 1
```
New: 
```
        olderThan: "14d"
        keep: 1
        repoTagFilters: [".*:^pr-.*", "^labs/.*:.*", "^toffee.*:.*", "^plum.*:.*"]
```

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)