### PR TITLE
Revert change that caused deleting of all plum and toffee tags

### DIFF
--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -34,7 +34,7 @@ parameters:
         repoTagFilters: [".*:^staging-.*"]
       - olderThan: "14d"
         keep: 1
-        repoTagFilters: [".*:^pr-.*", "^toffee.*:^latest", "^plum.*:^latest"]
+        repoTagFilters: [".*:^pr-.*"]
       - olderThan: "14d"
         keep: 0
         repoTagFilters: ["^labs/.*:.*"]

--- a/builds/acr-cleanup/acr-registry-cleanup.yaml
+++ b/builds/acr-cleanup/acr-registry-cleanup.yaml
@@ -34,7 +34,10 @@ parameters:
         repoTagFilters: [".*:^staging-.*"]
       - olderThan: "14d"
         keep: 1
-        repoTagFilters: [".*:^pr-.*", "^labs/.*:.*", "^toffee.*:.*", "^plum.*:.*"]
+        repoTagFilters: [".*:^pr-.*", "^toffee.*:^latest", "^plum.*:^latest"]
+      - olderThan: "14d"
+        keep: 0
+        repoTagFilters: ["^labs/.*:.*"]
 
 jobs:
   - ${{ each cleanup_registry in parameters.cleanup_registries }}:


### PR DESCRIPTION
complete remove '^labs/.*' images older than 14 days

### Jira link (if applicable)


### Change description ###
Some improvements introduced in defining `clean_patterns` object (DTSPO-18162) as a result some toffee images somehow were deleted e.g. 

`
Failed to pull image "sdshmctspublic.azurecr.io/toffee/frontend:prod-1a1582e-20240610094148": rpc error: code = NotFound desc = failed to pull and unpack image "sdshmctspublic.azurecr.io/toffee/frontend:prod-1a1582e-20240610094148": failed to resolve reference "sdshmctspublic.azurecr.io/toffee/frontend:prod-1a1582e-20240610094148": sdshmctspublic.azurecr.io/toffee/frontend:prod-1a1582e-20240610094148: not found
`
This PR aims to fix the above issue.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)